### PR TITLE
update axis order for wgs_crs defined in the library for GDAL3+

### DIFF
--- a/pygeotools/lib/geolib.py
+++ b/pygeotools/lib/geolib.py
@@ -24,7 +24,8 @@ wgs_srs = osr.SpatialReference()
 wgs_srs.SetWellKnownGeogCS('WGS84')
 wgs_proj = '+proj=longlat +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +no_defs '
 #GDAL3 hack
-#wgs_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+if int(gdal.__version__.split('.')[0]) >= 3:
+    wgs_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
 #Define ECEF srs
 ecef_srs=osr.SpatialReference()


### PR DESCRIPTION
Based on an error in [proj_select.py](https://github.com/dshean/pygeotools/blob/master/pygeotools/proj_select.py) by @jmichellehu, the output projection is wrong when we use the tool with a raster DEM.

Gleaning at the code, I figured that we need to set the axis order if gdal is 3+ when defining our own wgs_srs in the geolib library. Post that, the code works as expected!

Let me know if I need to provide additional comments/fixes